### PR TITLE
rosy: drivers: touchscreen: Restore lcd_power_ctrl calls

### DIFF
--- a/drivers/input/touchscreen/FT8006m/focaltech_core.c
+++ b/drivers/input/touchscreen/FT8006m/focaltech_core.c
@@ -1596,6 +1596,10 @@ static int ft8006m_ts_resume(struct device *dev)
     }
     fts_release_all_finger();
 
+    if (!(ft8006m_gesture_data.gesture_all_switch)){
+        lcd_power_ctrl(data, 1);
+    }
+
 #if (!FTS_CHIP_IDC)
     ft8006m_reset_proc(200);
 #endif

--- a/drivers/input/touchscreen/FT8716/focaltech_core.c
+++ b/drivers/input/touchscreen/FT8716/focaltech_core.c
@@ -1598,6 +1598,10 @@ static int fts_ts_resume(struct device *dev)
     }
     fts_release_all_finger();
 
+    if (!(gesture_data.gesture_all_switch)){
+        lcd_power_ctrl(data, 1);
+    }
+
 #if (!FTS_CHIP_IDC)
     fts_reset_proc(200);
 #endif


### PR DESCRIPTION
Fixes i2c error introduced after these were removed in commit 915bd65ee970c2aa828801a84baceecaff35b12a: i2c-msm-v2 78b7000.i2c: NACK: slave not responding, ensure its powered: msgs(n:1 cur:0 tx) bc(rx:0 tx:2) mode:FIFO slv_addr:0x38 MSTR_STS:0x0d1300c8 OPER:0x00000090